### PR TITLE
Lint fix

### DIFF
--- a/docs/guides/initialize-state-with-props.md
+++ b/docs/guides/initialize-state-with-props.md
@@ -35,7 +35,7 @@ const createBearStore = (initProps?: Partial<BearProps>) => {
 ## Creating a context with `React.createContext`
 
 ```ts
-import { createContext } from 'react';
+import { createContext } from 'react'
 
 export const BearContext = createContext<BearStore | null>(null)
 ```

--- a/docs/guides/initialize-state-with-props.md
+++ b/docs/guides/initialize-state-with-props.md
@@ -31,12 +31,13 @@ const createBearStore = (initProps?: Partial<BearProps>) => {
   }))
 }
 ```
+
 ## Creating a context with `React.createContext`
 
 ```ts
-import React, { createContext } from 'react';
+import React, { createContext } from 'react'
 
-export const BearContext = createContext<BearStore | null>(null);
+export const BearContext = createContext<BearStore | null>(null)
 ```
 
 ## Basic component usage

--- a/docs/guides/typescript.md
+++ b/docs/guides/typescript.md
@@ -93,7 +93,7 @@ So we have two problems: lack of inference and unsoundness. Lack of inference ca
 
   <br/>
 
-  **TLDR**: It is a workaround for [microsoft/TypeScript#10571](https://github.com/microsoft/TypeScript/issues/10571).
+**TLDR**: It is a workaround for [microsoft/TypeScript#10571](https://github.com/microsoft/TypeScript/issues/10571).
 
 Imagine you have a scenario like this:
 

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "build:shallow": "rollup -c --config-shallow",
     "build:context": "rollup -c --config-context",
     "postbuild": "yarn copy",
-    "prettier": "prettier '*.{js,json,md}' '{examples/src,src,tests,docs}/**/*.{js,jsx,ts,tsx,md,mdx}' --write",
+    "prettier": "prettier \"*.{js,json,md}\" \"{examples/src,src,tests,docs}/**/*.{js,jsx,ts,tsx,md,mdx}\" --write",
     "prettier:ci": "prettier '*.{js,json,md}' '{examples/src,src,tests,docs}/**/*.{js,jsx,ts,tsx,md,mdx}' --list-different",
     "eslint": "eslint --fix '*.{js,json}' '{src,tests}/**/*.{ts,tsx}'",
     "eslint:ci": "eslint '*.{js,json}' '{src,tests}/**/*.{ts,tsx}'",


### PR DESCRIPTION
## Related Issues

Fixes #.

## Summary
Change the single quotes to escaped double quotes:
```diff
- "prettier --write '.{js,json,md}` ... "
+ "prettier --write \".{js,json,md}\" ..."
```

## Check List

- [ ] `yarn run prettier` for formatting code and docs
